### PR TITLE
NetBSD support

### DIFF
--- a/src/nuspell/utils.hxx
+++ b/src/nuspell/utils.hxx
@@ -125,7 +125,7 @@ class Encoding_Converter {
 };
 
 //#if _POSIX_VERSION >= 200809L
-#ifdef _POSIX_VERSION
+#if defined(_POSIX_VERSION) && !defined(__NetBSD__)
 class Setlocale_To_C_In_Scope {
 	locale_t old_loc = nullptr;
 


### PR DESCRIPTION
NetBSD does not have a uselocale library call, so I had to patch one file. The better approach would probably be to check if there is a `uselocale` call from the CMake side.

I also created a "work in progress" package for pkgsrc, the NetBSD package collection. See http://pkgsrc.se/wip/nuspell. As this is for 3.0.0, I also had to patch the "wchar is unicode" check that was removed from the development branch.

One question: is there supposed to be a shared library? Right now, it only builds a `.a` file on NetBSD.