### PR TITLE
Fix for windows console code page

### DIFF
--- a/src/nuspell/main.cxx
+++ b/src/nuspell/main.cxx
@@ -615,6 +615,8 @@ int main(int argc, char* argv[])
 	char* loc_str = nullptr;
 #ifdef _WIN32
 	loc_str = setlocale(LC_CTYPE, nullptr); // will return "C"
+	SetConsoleCP(GetACP());
+	SetConsoleOutputCP(GetACP());
 
 	/* On Windows, the console is a buggy thing. If the default C locale is
 	active, then the encoding of the strings gotten from C or C++ stdio


### PR DESCRIPTION
Hi. I have found a bug and would like to propose a small fix to it.

OS: Windows 21H1 x64 - English
Compiler - MSVC 2019 x64
Dictionary: Libre Office pt_BR (https://cgit.freedesktop.org/libreoffice/dictionaries/tree/pt_BR)

**Description:**
I noticed that my Windows has a default code page different from the one used by default in my console. See images below for details
![default windows cp](https://user-images.githubusercontent.com/20713928/119161873-2660b280-ba30-11eb-81e4-0c48bd5bdf2b.png)
![console cp](https://user-images.githubusercontent.com/20713928/119161883-2791df80-ba30-11eb-85d0-3bb0b7752049.png)

Because of that, stdin in console was changing words like "trovão" to "trovao", without the tilde above the "a". Stdout was also printing wrongly
![bug](https://user-images.githubusercontent.com/20713928/119161880-2791df80-ba30-11eb-8c82-ece316722209.png)

The fix is to simply set console code page to default windows system code page. After the fix, everything is fine
![with_fix](https://user-images.githubusercontent.com/20713928/119161878-26f94900-ba30-11eb-9439-034920e2b1e1.png)