### PR TITLE
CMake: Skip search for C compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(nuspell VERSION 5.0.1)
+project(nuspell VERSION 5.0.1 LANGUAGES CXX)
 set(PROJECT_HOMEPAGE_URL "https://nuspell.github.io/")
 
 option(BUILD_SHARED_LIBS "Build as shared library" ON)


### PR DESCRIPTION
Since only C++ is used, we don't need CMake to look for a C compiler.