### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ manuals.
 4.  Install Pandoc. You can manually install or use `choco install pandoc`.
 4.  Install Doxygen. You can manually install or use
     `choco install doxygen.install`.
-5.  Run the commands bellow. Vcpkg will work in manifest mode and it will
+5.  Run the commands below. Vcpkg will work in manifest mode and it will
     automatically install the dependencies.
 
 <!-- end list -->

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -3,7 +3,7 @@ if (BUILD_MAN)
 
 	if (NOT PANDOC_EXECUTABLE)
 		message(FATAL_ERROR "Pandoc not found, can not build the "
-			"man-pages. Either install Pandoc or disable builing "
+			"man-pages. Either install Pandoc or disable building "
 			"the man-pages with cmake -DBUILD_MAN=OFF.")
 	endif()
 

--- a/docs/nuspell.1.md
+++ b/docs/nuspell.1.md
@@ -4,7 +4,7 @@ section: 1
 header: User Commands
 footer: Nuspell vX.Y  # override this on the command line in CMake
 author: Dimitrij Mijoski
-date: 2024-07-03 # This date should be changed when signifcant changes in this
+date: 2024-07-03 # This date should be changed when significant changes in this
                  # document are made. It is not release date or build date.
 ---
 

--- a/src/nuspell/checker.cxx
+++ b/src/nuspell/checker.cxx
@@ -52,7 +52,7 @@ auto Checker::spell_priv(string& s) const -> bool
 	// do input conversion (iconv)
 	input_substr_replacer.replace(s);
 
-	// triming whitespace should be part of tokenization, not here
+	// trimming whitespace should be part of tokenization, not here
 
 	if (s.empty())
 		return true;
@@ -87,7 +87,7 @@ auto Checker::spell_priv(string& s) const -> bool
 
 auto Checker::spell_break(std::string& s, size_t depth) const -> bool
 {
-	// check spelling accoring to case
+	// check spelling according to case
 	auto res = spell_casing(s);
 	if (res) {
 		// handle forbidden words
@@ -245,7 +245,7 @@ auto Checker::spell_casing_title(std::string& s) const -> const Flag_Set*
  * of minimal one replacement of 'ss' with sharp s 'ß'. Maximum recursion depth
  * is limited with a hardcoded value.
  *
- * @param base string to check spelling for where zero or more occurences of
+ * @param base string to check spelling for where zero or more occurrences of
  * 'ss' have been replaced by sharp s 'ß'.
  * @param pos position in the string to start next find and replacement.
  * @param n counter for the recursion depth.

--- a/src/nuspell/finder.cxx
+++ b/src/nuspell/finder.cxx
@@ -172,7 +172,7 @@ auto append_libreoffice_dir_paths(vector<fs_path>& paths) -> void
 	try {
 #if _WIN32
 		auto lo_dir = wstring(MAX_PATH - 1, '*');
-		// size in bytes including the zero teminator
+		// size in bytes including the zero terminator
 		DWORD lo_dir_sz = (size(lo_dir) + 1) * sizeof(wchar_t);
 		auto subkey = L"SOFTWARE\\LibreOffice\\UNO\\InstallPath";
 		auto regerr = RegGetValueW(HKEY_LOCAL_MACHINE, subkey, nullptr,
@@ -250,10 +250,10 @@ auto append_libreoffice_dir_paths(vector<fs_path>& paths) -> void
 }
 
 /**
- * @brief Serach the directories for only one dictionary
+ * @brief Search the directories for only one dictionary
  *
  * This function is more efficient than search_dirs_for_dicts() because it
- * does not iterate whole directories, it only checks the existance of .dic and
+ * does not iterate whole directories, it only checks the existence of .dic and
  * .aff files. Useful for some CLI tools. GUI apps generally need a list of all
  * dictionaries.
  *

--- a/src/nuspell/structures.hxx
+++ b/src/nuspell/structures.hxx
@@ -233,7 +233,7 @@ class String_Set {
 	void swap(String_Set& s) { d.swap(s.d); }
 	void clear() noexcept { d.clear(); }
 
-	// non standrd modifiers:
+	// non standard modifiers:
 	auto insert(const Str& s) -> void
 	{
 		d += s;

--- a/src/nuspell/suggester.cxx
+++ b/src/nuspell/suggester.cxx
@@ -193,7 +193,7 @@ auto Suggester::suggest_priv(string_view input_word, List_Strings& out) const
 		};
 		auto it = begin(out);
 		auto last = end(out);
-		// Bellow is remove_if(it, last, is_not_ok);
+		// Below is remove_if(it, last, is_not_ok);
 		// We don't use remove_if because is_ok modifies
 		// the argument.
 		for (; it != last; ++it)

--- a/src/nuspell/unicode.hxx
+++ b/src/nuspell/unicode.hxx
@@ -201,7 +201,7 @@ auto valid_u16_write_cp_and_advance(Range& buf, size_t& i, char32_t cp) -> void
 	U16_APPEND_UNSAFE(buf, i, cp);
 }
 
-// higer level funcs
+// higher level funcs
 
 struct U8_CP_Pos {
 	size_t begin_i = 0;
@@ -272,7 +272,7 @@ auto inline u8_swap_cp(std::string& str, U8_CP_Pos pos1, U8_CP_Pos pos2)
 	return {new_p1_end_i, new_p2_begin_i};
 }
 
-// bellow go func without out-parametars
+// below go func without out-parametars
 
 // UTF-8, can be malformed, no out-parametars
 

--- a/src/nuspell/utils.cxx
+++ b/src/nuspell/utils.cxx
@@ -39,14 +39,14 @@ NUSPELL_BEGIN_INLINE_NAMESPACE
 
 /**
  * @internal
- * @brief Splits string on set of single char seperators.
+ * @brief Splits string on set of single char separators.
  *
  * Consecutive separators are treated as separate and will emit empty strings.
  *
  * @deprecated TODO delete this on new major version. it was exported internal
  * symbol, but now it isn't used internally. it was exported for unit_test.
  * @param s string to split.
- * @param sep seperator(s) to split on.
+ * @param sep separator(s) to split on.
  * @param out vector where separated strings are appended.
  * @return @p out.
  */
@@ -376,8 +376,8 @@ auto erase_chars(string& s, string_view erase_chars) -> void
  * @internal
  * @brief Tests if word is a number.
  *
- * Allow numbers with dot ".", dash "-" or comma "," inbetween the digits, but
- * forbids double separators such as "..", "--" and ".,".
+ * Allow numbers with dot ".", dash "-" or comma "," in between the digits,
+ * but forbids double separators such as "..", "--" and ".,".
  */
 auto is_number(string_view s) -> bool
 {

--- a/src/tools/nuspell.cxx
+++ b/src/tools/nuspell.cxx
@@ -483,7 +483,7 @@ int main(int argc, char* argv[])
 	// used. We should check for runtime errors.
 	// The encoding conversion is a common case where runtime error can
 	// happen, but by default ICU uses Unicode replacement character on
-	// errors and reprots success. This can be changed, but there is no need
+	// errors and reports success. This can be changed, but there is no need
 	// for that.
 	auto uerr = U_ZERO_ERROR;
 	auto inp_enc_cstr = input_enc.c_str();


### PR DESCRIPTION
https://pypi.org/project/codespell

% `codespell --skip="./external/*,./tests/*" --count`
```
./README.md:109: bellow ==> below
./docs/CMakeLists.txt:6: builing ==> building
./docs/nuspell.1.md:7: signifcant ==> significant
./src/tools/nuspell.cxx:486: reprots ==> reports
./src/nuspell/checker.cxx:55: triming ==> trimming, timing
./src/nuspell/checker.cxx:90: accoring ==> according, occurring
./src/nuspell/checker.cxx:248: occurences ==> occurrences
./src/nuspell/finder.cxx:175: teminator ==> terminator
./src/nuspell/finder.cxx:253: Serach ==> Search
./src/nuspell/finder.cxx:256: existance ==> existence
./src/nuspell/structures.hxx:236: standrd ==> standard
./src/nuspell/suggester.cxx:196: Bellow ==> Below
./src/nuspell/unicode.hxx:204: higer ==> higher
./src/nuspell/unicode.hxx:275: bellow ==> below
./src/nuspell/utils.cxx:42: seperators ==> separators
./src/nuspell/utils.cxx:49: seperator ==> separator
./src/nuspell/utils.cxx:379: inbetween ==> between, in between
17
```
% `codespell --skip="./external/*,./tests/*" --write-changes`